### PR TITLE
Upgrade to Scala.js 1.19.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val `sjsir-interpreter` = project
   .settings(
     scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "40"),
     libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-linker" % "1.18.0",
+      "org.scala-js" %%% "scalajs-linker" % "1.19.0",
       "org.scalameta" %%% "munit" % "0.7.29" % Test,
     ),
     scalaJSLinkerConfig ~= {
@@ -196,9 +196,11 @@ lazy val `scalajs-test-suite` = project
       Seq(
         base / "test-suite/shared/src/test/scala",
         base / "test-suite/js/src/test/require-2.12",
+        // base / "test-suite/js/src/test/require-async-await", // TODO
         base / "test-suite/js/src/test/require-exponent-op",
         base / "test-suite/js/src/test/require-new-target",
         base / "test-suite/js/src/test/require-no-modules",
+        // base / "test-suite/js/src/test/require-orphan-await", // Wasm-only
         base / "test-suite/js/src/test/require-sam",
         base / "test-suite/js/src/test/require-scala2",
         base / "test-suite/js/src/test/scala",

--- a/core/src/main/scala/org/scalajs/sjsirinterpreter/core/ClassInfo.scala
+++ b/core/src/main/scala/org/scalajs/sjsirinterpreter/core/ClassInfo.scala
@@ -11,6 +11,7 @@ import org.scalajs.ir.Names._
 import org.scalajs.ir.Position
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
+import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.linker.interface.unstable.RuntimeClassNameMapperImpl
 
@@ -177,6 +178,12 @@ private[core] final class ClassInfo(val interpreter: Interpreter,
     resolvedPublicMethods.getOrElseUpdate(methodName, {
       resolvePublicMethod(methodName)
     })
+  }
+
+  def lookupSingleConstructor()(implicit pos: Position): MethodInfo = {
+    val methods = directMethods(MemberNamespace.Constructor)
+    assert(methods.sizeIs == 1, s"Expected a single constructor in $className at $pos")
+    methods.head._2
   }
 
   def maybeLookupStaticConstructor(ctorName: MethodName): Option[MethodInfo] =

--- a/core/src/main/scala/org/scalajs/sjsirinterpreter/core/Interpreter.scala
+++ b/core/src/main/scala/org/scalajs/sjsirinterpreter/core/Interpreter.scala
@@ -16,6 +16,7 @@ final class Interpreter(val semantics: Semantics) {
   private var working: Boolean = false
 
   private val classInfos = mutable.Map.empty[ClassName, ClassInfo]
+  private val lambdaClassInfos = mutable.HashMap.empty[NewLambda.Descriptor, ClassInfo]
   private[core] val executor = new Executor(this)
   private[core] val compiler = new Compiler(this)
 
@@ -33,6 +34,17 @@ final class Interpreter(val semantics: Semantics) {
   private[core] def getClassInfo(className: ClassName)(implicit pos: Position): ClassInfo = {
     classInfos.getOrElse(className, {
       throw new AssertionError(s"Cannot find class ${className.nameString} at $pos")
+    })
+  }
+
+  private[core] def getLambdaClassInfo(descriptor: NewLambda.Descriptor)(
+      implicit pos: Position): ClassInfo = {
+    lambdaClassInfos.getOrElseUpdate(descriptor, {
+      val classDef = LambdaSynthesizer.makeClassDef(descriptor)
+      val className = classDef.className
+      val classInfo = new ClassInfo(this, className, classDef)
+      classInfos(className) = classInfo
+      classInfo
     })
   }
 

--- a/core/src/main/scala/org/scalajs/sjsirinterpreter/core/LambdaSynthesizer.scala
+++ b/core/src/main/scala/org/scalajs/sjsirinterpreter/core/LambdaSynthesizer.scala
@@ -1,0 +1,131 @@
+package org.scalajs.sjsirinterpreter.core
+
+import org.scalajs.ir.{ClassKind, Position, SHA1, UTF8String, Version}
+import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+import org.scalajs.ir.WellKnownNames._
+
+/** Mostly copied from `LambdaSynthesizer` in the linker. */
+private[core] object LambdaSynthesizer {
+  /* Everything we create has a constant version because the names are derived
+   * from the descriptors themselves.
+   */
+  private val constantVersion = Version.fromByte(0)
+
+  private val ClosureTypeRefName = LabelName("c")
+  private val fFieldSimpleName = SimpleFieldName("f")
+
+  /** Deterministically makes a class name for the lambda class given its descriptor.
+   *
+   *  This computation is mildly expensive. Callers should cache it if possible.
+   */
+  private def makeClassName(descriptor: NewLambda.Descriptor): ClassName = {
+    // Choose a base class name that will "makes sense" for debugging purposes
+    val baseClassName = {
+      if (descriptor.superClass == ObjectClass && descriptor.interfaces.nonEmpty)
+        descriptor.interfaces.head
+      else
+        descriptor.superClass
+    }
+
+    val digestBuilder = new SHA1.DigestBuilder()
+    digestBuilder.updateUTF8String(descriptor.superClass.encoded)
+    for (intf <- descriptor.interfaces)
+      digestBuilder.updateUTF8String(intf.encoded)
+
+    // FIXME This is not efficient
+    digestBuilder.updateUTF8String(UTF8String(descriptor.methodName.nameString))
+
+    // No need the hash the paramTypes and resultType because they derive from the method name
+
+    val digest = digestBuilder.finalizeDigest()
+
+    /* The "$$Lambda" segment is meant to match the way LambdaMetaFactory
+     * names generated classes. This is mostly for test compatibility
+     * purposes (like partests that test the class name to tell whether a
+     * lambda was indeed encoded as an LMF).
+     */
+    val suffixBuilder = new java.lang.StringBuilder(".$$Lambda$")
+    for (b <- digest) {
+      val i = b & 0xff
+      suffixBuilder.append(Character.forDigit(i >> 4, 16)).append(Character.forDigit(i & 0x0f, 16))
+    }
+
+    ClassName(baseClassName.encoded ++ UTF8String(suffixBuilder.toString()))
+  }
+
+  /** Computes the constructor name for the lambda class of a descriptor. */
+  private def makeConstructorName(descriptor: NewLambda.Descriptor): MethodName = {
+    val closureTypeNonNull =
+      ClosureType(descriptor.paramTypes, descriptor.resultType, nullable = false)
+    MethodName.constructor(TransientTypeRef(ClosureTypeRefName)(closureTypeNonNull) :: Nil)
+  }
+
+  /** Synthesizes the `ClassDef` for a lambda class, for use by the `BaseLinker`. */
+  def makeClassDef(descriptor: NewLambda.Descriptor): ClassDef = {
+    implicit val pos = Position.NoPosition
+
+    import descriptor._
+
+    val className = makeClassName(descriptor)
+
+    val closureType = ClosureType(paramTypes, resultType, nullable = true)
+
+    val thiz = This()(ClassType(className, nullable = false))
+
+    val fFieldIdent = FieldIdent(FieldName(className, fFieldSimpleName))
+    val fFieldDef = FieldDef(MemberFlags.empty, fFieldIdent, NoOriginalName, closureType)
+    val fFieldSelect = Select(thiz, fFieldIdent)(closureType)
+
+    val ctorParamDef = ParamDef(LocalIdent(LocalName("f")), NoOriginalName,
+        closureType.toNonNullable, mutable = false)
+    val ctorDef = MethodDef(
+      MemberFlags.empty.withNamespace(MemberNamespace.Constructor),
+      MethodIdent(makeConstructorName(descriptor)),
+      NoOriginalName,
+      ctorParamDef :: Nil,
+      VoidType,
+      Some(
+        Block(
+          Assign(fFieldSelect, ctorParamDef.ref),
+          ApplyStatically(ApplyFlags.empty.withConstructor(true), thiz,
+              superClass, MethodIdent(NoArgConstructorName), Nil)(VoidType)
+        )
+      )
+    )(OptimizerHints.empty, constantVersion)
+
+    val methodParamDefs = paramTypes.zipWithIndex.map { case (paramType, index) =>
+      ParamDef(LocalIdent(LocalName("x" + index)), NoOriginalName, paramType, mutable = false)
+    }
+    val methodDef = MethodDef(
+      MemberFlags.empty,
+      MethodIdent(methodName),
+      NoOriginalName,
+      methodParamDefs,
+      resultType,
+      Some(
+        ApplyTypedClosure(ApplyFlags.empty, fFieldSelect, methodParamDefs.map(_.ref))
+      )
+    )(OptimizerHints.empty, constantVersion)
+
+    ClassDef(
+      ClassIdent(className),
+      NoOriginalName,
+      ClassKind.Class,
+      jsClassCaptures = None,
+      superClass = Some(ClassIdent(superClass)),
+      interfaces = interfaces.map(ClassIdent(_)),
+      jsSuperClass = None,
+      jsNativeLoadSpec = None,
+      fields = List(fFieldDef),
+      methods = List(ctorDef, methodDef),
+      jsConstructor = None,
+      jsMethodProps = Nil,
+      jsNativeMembers = Nil,
+      topLevelExportDefs = Nil
+    )(OptimizerHints.empty.withInline(true))
+  }
+
+}

--- a/core/src/test/scala/org/scalajs/sjsirinterpreter/core/TestIRBuilder.scala
+++ b/core/src/test/scala/org/scalajs/sjsirinterpreter/core/TestIRBuilder.scala
@@ -11,6 +11,7 @@ import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
 import org.scalajs.ir.Version
+import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.linker.interface.ModuleInitializer
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.18.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.2.0.201312181205-r"


### PR DESCRIPTION
The most notable addition is `NewLambda` + typed closures.

Async closures are not supported.